### PR TITLE
Fix enclave_enter thread vulnerability

### DIFF
--- a/src/api/enclave_enter.c
+++ b/src/api/enclave_enter.c
@@ -54,6 +54,12 @@ api_result_t sm_internal_enclave_enter (enclave_id_t enclave_id, thread_id_t thr
     return result;
   }
 
+  // thread must belong to this enclave
+  if (thread_metadata->owner != enclave_id) {
+      unlock_regions(&locked_regions);
+      return MONITOR_INVALID_STATE;
+  }
+
   // the tread must not be scheduled
   if(thread_metadata->is_scheduled) {
     unlock_regions(&locked_regions);


### PR DESCRIPTION
Problem:

An attacker could execute arbitrary code in an enclave by passing a
thread_id from a different enclave to sm_enclave_enter() and having it
execute from the shared page.

Solution:

Verify that the owner of the thread is the enclave that is being started.